### PR TITLE
github release script enhancements aimed at cron based operation

### DIFF
--- a/github_release_script.py
+++ b/github_release_script.py
@@ -34,8 +34,7 @@ args=parser.parse_args()
 #Reset draft and prerelease args to lower case for json consumption
 args.draft="{0}".format(args.draft).lower()
 args.prerelease="{0}".format(args.prerelease).lower()
-print args
-sys,exit(0)
+
 # Setup Path 
 if args.path is None:
   args.path=xdg.BaseDirectory.save_config_path("github_release_script")


### PR DESCRIPTION
Feature Enhancements:
- Added cmdline option to set release message body text
- Added autodetection of existing release that matches latest commit, to avoid generating duplicate releases
- Added force cmdline option to disable duplicate detection and force a release tag generation. 
- Added cmdline options to enable draft and prerelease flags in the github release api.

So the idea is, you can run this script out of cron.. if no new commits have happened since the last release, then the script will not generate a new release unless forced to do so. Only release when it makes since to do so because there has been a new commit. Keep unnecessary churn down for everyone not using the git repo directly.

We can actually take this further and compare latest commit to release commit and see if there are file changes between commits, but I don't think that's necessary for hdw.dat repo.
